### PR TITLE
Update dependencies on Gemfile with rake task that shows outdated gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,25 +21,25 @@ source 'https://rubygems.org'
 ruby '2.3.3'
 
 gem 'aws-sdk-dynamodb', '1.4.0'
-gem 'aws-sdk-s3', '1.8.1'
+gem 'aws-sdk-s3', '1.8.2'
 gem 'codecov', '0.1.10'
-gem 'glogin'
+gem 'glogin', '0.2.1'
 gem 'haml', '5.0.4'
 gem 'mail', '2.7.0'
 gem 'mocha', require: false
-gem 'nokogiri', '~>1.8'
+gem 'nokogiri', '~>1.8.2'
 gem 'octokit', '4.8.0'
 gem 'pdd', '0.20.3'
-gem 'rack', '~> 2.0'
-gem 'rack-test', '0.8.2'
+gem 'rack', '~> 2.0.4'
+gem 'rack-test', '0.8.3'
 gem 'rake', '12.3.0', require: false
 gem 'rspec-rails', '3.7.2', require: false
 gem 'rubocop', '0.53.0', require: false
-gem 'rubocop-rspec', '1.22.2', require: false
+gem 'rubocop-rspec', '1.24.0', require: false
 gem 'sass', '3.5.5'
-gem 'sentry-raven', '~>2.6'
+gem 'sentry-raven', '~>2.7.2'
 gem 'sinatra', '2.0.1'
-gem 'sinatra-contrib', '~>2.0'
+gem 'sinatra-contrib', '~>2.0.1'
 gem 'sprockets', '3.7.1'
 gem 'test-unit', '3.2.7', require: false
 gem 'xcop', '0.5.8'

--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,7 @@ require_relative 'objects/dynamo'
 
 ENV['RACK_ENV'] = 'test'
 
-task default: %i[clean test rubocop xcop copyright]
+task default: %i[check_outdated_gems clean test rubocop xcop copyright]
 
 require 'rake/testtask'
 desc 'Run all unit tests'
@@ -91,4 +91,10 @@ task :copyright do
     --include '*.txt' \
     --include 'Rakefile' \
     ."
+end
+
+task :check_outdated_gems do
+  sh 'bundle outdated' do |ok, _|
+    puts 'Some dependencies are outdated' unless ok
+  end
 end


### PR DESCRIPTION
The rake task does not fails when it finds outdated dependencies because sometimes are dependencies of some gem listed in the Gemfile, so in that case will be almost impossible to fix it. The output of _sh_ is wrapped around puts because a failure in _bundle outdated_ results in stopping the run of remaining tasks when _rake_, so i think that is better to only display a message. 
Work for #133 