### PR TITLE
Updated dependencies. Closes #133

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,8 @@
 source 'https://rubygems.org'
 ruby '2.3.3'
 
-gem 'aws-sdk-dynamodb', '1.4.0'
-gem 'aws-sdk-s3', '1.8.2'
+gem 'aws-sdk-dynamodb', '1.5.0'
+gem 'aws-sdk-s3', '1.9.0'
 gem 'codecov', '0.1.10'
 gem 'glogin', '0.2.1'
 gem 'haml', '5.0.4'
@@ -31,12 +31,12 @@ gem 'nokogiri', '~>1.8.2'
 gem 'octokit', '4.8.0'
 gem 'pdd', '0.20.3'
 gem 'rack', '~> 2.0.4'
-gem 'rack-test', '0.8.3'
-gem 'rake', '12.3.0', require: false
+gem 'rack-test', '1.0.0'
+gem 'rake', '12.3.1', require: false
 gem 'rspec-rails', '3.7.2', require: false
-gem 'rubocop', '0.53.0', require: false
-gem 'rubocop-rspec', '1.24.0', require: false
-gem 'sass', '3.5.5'
+gem 'rubocop', '0.54.0', require: false
+gem 'rubocop-rspec', '1.25.0', require: false
+gem 'sass', '3.5.6'
 gem 'sentry-raven', '~>2.7.2'
 gem 'sinatra', '2.0.1'
 gem 'sinatra-contrib', '~>2.0.1'


### PR DESCRIPTION
Closes #133. 

Updated all outdated dependencies except for 'slop' since it's a transitive dependency from pdd. pdd gem would need to be updated in order to update slop.