### PR TITLE
Puzzle Body conditional Estimate/Role inclusion. Fixes #70

### DIFF
--- a/objects/github_tickets.rb
+++ b/objects/github_tickets.rb
@@ -20,6 +20,7 @@
 
 require 'octokit'
 require_relative 'truncated'
+require_relative 'maybe_text'
 
 #
 # Tickets in Github.
@@ -118,8 +119,10 @@ from ##{puzzle.xpath('ticket')[0].text} has to be resolved:\
 The puzzle was created by #{puzzle.xpath('author')[0].text} on \
 #{Time.parse(puzzle.xpath('time')[0].text).strftime('%d-%b-%y')}. \
 \n\n\
-Estimate: #{puzzle.xpath('estimate')[0].text} minutes, \
-role: #{puzzle.xpath('role')[0].text}.\
+#{MaybeText.new("Estimate: #{puzzle.xpath('estimate')[0].text} minutes, ",
+                puzzle.xpath('estimate')[0].text)}  \
+#{MaybeText.new("role: #{puzzle.xpath('role')[0].text}.",
+                puzzle.xpath('role')[0].text, 'IMP')}  \
 \n\n\
 If you have any technical questions, don't ask me, \
 submit new tickets instead. The task will be \"done\" when \

--- a/objects/maybe_text.rb
+++ b/objects/maybe_text.rb
@@ -1,0 +1,38 @@
+# Copyright (c) 2016-2018 Yegor Bugayenko
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the 'Software'), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+#
+# Maybe text
+#
+class MaybeText
+  def initialize(text_if_present, maybe, exclude_if = false)
+    @maybe = maybe
+    @text = text_if_present
+    @exclude_if = exclude_if
+  end
+
+  def to_s
+    if @maybe.nil? || @maybe.empty? || @maybe <=> @exclude_if
+      ''
+    else
+      @text
+    end
+  end
+end

--- a/test/test_maybe_text.rb
+++ b/test/test_maybe_text.rb
@@ -1,0 +1,42 @@
+# Copyright (c) 2016-2018 Yegor Bugayenko
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the 'Software'), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+require 'test/unit'
+require_relative 'test__helper'
+require_relative '../objects/maybe_text'
+
+# Truncated test.
+class TestMaybeText < Test::Unit::TestCase
+  def test_nil_input_then_blank
+    assert_equal('', MaybeText.new('output', nil).to_s)
+  end
+
+  def test_empty_input_then_blank
+    assert_equal('', MaybeText.new('output', '').to_s)
+  end
+
+  def test_excluded_input_then_blank
+    assert_equal('', MaybeText.new('output', 'exc', 'exc').to_s)
+  end
+
+  def test_present_input_then_output
+    assert_equal('output', MaybeText.new('output', 'input').to_s)
+  end
+end


### PR DESCRIPTION
Puzzle Body now displays more nicely. Fixes #70.

Added new `MaybeText` object and unit tests.

Will hide Estimate if not present in Puzzle Body.
Will hide Role if is "IMP" in Puzzle Body.
