### PR TITLE
Retrieves Organization Invitations from GitHub. Closes #143

### DIFF
--- a/0pdd.rb
+++ b/0pdd.rb
@@ -245,7 +245,7 @@ get '/ping-github' do
     puts "Repository invitation #{i['id']} accepted"
   end
   gh.organization_invitations.each do |i|
-    # @todo #194:30min Need to figure out the correct way to accept the 
+    # @todo #194:30min Need to figure out the correct way to accept the
     #  Organization Invitation. It's not quite clear.
     # Octokit Doc Link: https://bit.ly/2qFkfpU
   end

--- a/0pdd.rb
+++ b/0pdd.rb
@@ -242,7 +242,12 @@ get '/ping-github' do
   gh = settings.github
   gh.user_repository_invitations.each do |i|
     gh.accept_repository_invitation(i['id'])
-    puts "Invitation #{i['id']} accepted"
+    puts "Repository invitation #{i['id']} accepted"
+  end
+  gh.organization_invitations.each do |i|
+    # @todo #194:30min Need to figure out the correct way to accept the 
+    #  Organization Invitation. It's not quite clear.
+    # Octokit Doc Link: https://bit.ly/2qFkfpU
   end
   gh.notifications.map do |n|
     reason = n['reason']


### PR DESCRIPTION
Closes #134. Discovered how to retrieve list of Github Organization Invites. 

- Created a puzzle for figuring out how to accept Organization Invites.
- Updated Repository invitation message to disambiguate from other invitation acceptances
