### PR TITLE
(#174) Inherit milestones

### DIFF
--- a/0pdd.rb
+++ b/0pdd.rb
@@ -324,10 +324,15 @@ post '/hook/github' do
                         LoggedTickets.new(
                           Log.new(settings.dynamo, name),
                           name,
-                          GithubTickets.new(
+                          MilestoneTickets.new(
                             name,
+                            repo,
                             settings.github,
-                            repo
+                            GithubTickets.new(
+                              name,
+                              settings.github,
+                              repo
+                            )
                           )
                         )
                       )

--- a/objects/milestone_tickets.rb
+++ b/objects/milestone_tickets.rb
@@ -40,7 +40,7 @@ class MilestoneTickets
     if @sources.config.dig('tickets', 'inherit-milestone')
       num = puzzle.xpath('ticket')[0].text
       parent = @github.issue(@repo, num)
-      unless parent.nil? or parent.['milestone'].nil?
+      unless parent.nil? or parent['milestone'].nil?
         begin
           @github.update_issue(@repo, num, { :milestone => parent['milestone']['number'] })
           unless @sources.config.dig('alerts', 'suppress', 'on-inherited-milestone')

--- a/objects/milestone_tickets.rb
+++ b/objects/milestone_tickets.rb
@@ -59,6 +59,7 @@ to us with the text you see below:\
           )
         end
       end
+    end
   end
 
   def close(puzzle)

--- a/objects/milestone_tickets.rb
+++ b/objects/milestone_tickets.rb
@@ -37,13 +37,14 @@ class MilestoneTickets
 
   def submit(puzzle)
     submitted = @tickets.submit(puzzle)
-    if @sources.config.dig('tickets', 'inherit-milestone')
-      num = puzzle.xpath('ticket')[0].text
+    config = @sources.config
+    if config['tickets'] and config['tickets'].include?('inherit-milestone') and puzzle.xpath('ticket')[0].text =~ /[0-9]+/
+      num = puzzle.xpath('ticket')[0].text.to_i
       parent = @github.issue(@repo, num)
       unless parent.nil? or parent['milestone'].nil?
         begin
           @github.update_issue(@repo, num, { :milestone => parent['milestone']['number'] })
-          unless @sources.config.dig('alerts', 'suppress', 'on-inherited-milestone')
+          unless config.dig('alerts', 'suppress') and config.dig('alerts', 'suppress').include?('on-inherited-milestone')
             @github.add_comment(
               @repo, submitted[:number],
               "This puzzle inherited milestone `#{parent['milestone']['title']}` from issue ##{num}."

--- a/objects/milestone_tickets.rb
+++ b/objects/milestone_tickets.rb
@@ -1,0 +1,67 @@
+# Copyright (c) 2016-2018 Yegor Bugayenko
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the 'Software'), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+require 'octokit'
+
+#
+# Tickets that inherit milestones.
+#
+class MilestoneTickets
+  def initialize(repo, sources, github, tickets)
+    @repo = repo
+    @sources = sources
+    @github = github
+    @tickets = tickets
+  end
+
+  def notify(issue, message)
+    @tickets.notify(issue, message)
+  end
+
+  def submit(puzzle)
+    submitted = @tickets.submit(puzzle)
+    if @sources.config.dig('tickets', 'inherit-milestone')
+      num = puzzle.xpath('ticket')[0].text
+      parent = @github.issue(@repo, num)
+      unless parent.nil? or parent.['milestone'].nil?
+        begin
+          @github.update_issue(@repo, num, { :milestone => parent['milestone']['number'] })
+          unless @sources.config.dig('alerts', 'suppress', 'on-inherited-milestone')
+            @github.add_comment(
+              @repo, submitted[:number],
+              "This puzzle inherited milestone `#{parent['milestone']['title']}` from issue ##{num}."
+            )
+          end
+        rescue Octokit::Error => e
+          @github.add_comment(
+            @repo, submitted[:number],
+            "For some reason I wasn't able to set milestone `#{parent['milestone']['title']}`, \
+inherited from `#{num}`, to this issue. Please, [submit a ticket](https://github.com/yegor256/0pdd/issues/new) \
+to us with the text you see below:\
+\n\n```#{e.class.name}\n#{e.message}\n#{e.backtrace.join("\n")}\n```"
+          )
+        end
+      end
+  end
+
+  def close(puzzle)
+    @tickets.close(puzzle)
+  end
+end

--- a/test/test_milestone_tickets.rb
+++ b/test/test_milestone_tickets.rb
@@ -78,7 +78,6 @@ alerts:
   end
   
   def test_does_not_set_milestone
-    set = false
     sources = Object.new
     def sources.config
       YAML.safe_load("")
@@ -87,8 +86,11 @@ alerts:
     def github.issue(_, _)
       { "milestone" => { "number" => 123, "title" => "v1.0" } }
     end
-    define_method github.update_issue(_, _, options)
-      set = true
+    def github.update_issue(_, _, options)
+      @updated = true
+    end
+    class << github
+      attr_accessor :updated
     end
     tickets = Object.new
     def tickets.submit(puzzle)
@@ -110,7 +112,7 @@ alerts:
         </puzzle>'
       ).xpath('/puzzle')
     )
-    assert_equal(false, set)
+    assert(not github.updated?)
   end
   
   def test_adds_comment
@@ -159,3 +161,4 @@ tickets:
     assert(github.comment.starts_with?('This puzzle inherited milestone'))
   end
 end
+

--- a/test/test_milestone_tickets.rb
+++ b/test/test_milestone_tickets.rb
@@ -1,0 +1,161 @@
+# Copyright (c) 2016-2018 Yegor Bugayenko
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the 'Software'), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+require 'test/unit'
+require 'nokogiri'
+require 'yaml'
+require 'fake_github'
+require_relative 'test__helper'
+require_relative '../objects/milestone_tickets'
+
+# MilestoneTickets test.
+# Author:: George Aristy (george.aristy@gmail.com)
+# Copyright:: Copyright (c) 2016-2018 Yegor Bugayenko
+# License:: MIT
+class TestGithubTickets < Test::Unit::TestCase
+  def test_sets_milestone
+    MILESTONE_NUM = 123
+    sources = Object.new
+    def sources.config
+      YAML.safe_load(
+        "
+tickets:
+  - inherit-milestone
+alerts:
+  suppress:
+    - on-inherited-milestone
+"
+      )
+    end
+    github = FakeGithub.new
+    def github.issue(_, _)
+      { "milestone" => { "number" => MILESTONE_NUM, "title" => "v1.0" } }
+    end
+    def github.update_issue(_, _, options)
+      @milestone = options['milestone']
+    end
+    class << github
+      attr_accessor :milestone
+    end
+    tickets = Object.new
+    def tickets.submit(puzzle)
+      { number: '123', href: 'http://0pdd.com' }
+    end
+    test = MilestoneTickets.new('yegor256/0pdd', sources, github, tickets)
+    test.submit(
+      Nokogiri::XML(
+        '<puzzle>
+          <id>23-ab536de</id>
+          <file>/a/b/c/test.txt</file>
+          <time>01-01-2017</time>
+          <author>yegor</author>
+          <body>привет дорогой друг, как твои дела?</body>
+          <ticket>123</ticket>
+          <estimate>30</estimate>
+          <role>DEV</role>
+          <lines>1-3</lines>
+        </puzzle>'
+      ).xpath('/puzzle')
+    )
+    assert_equal(MILESTONE_NUM, github.milestone)
+  end
+  
+  def test_does_not_set_milestone
+    set = false
+    sources = Object.new
+    def sources.config
+      YAML.safe_load("")
+    end
+    github = FakeGithub.new
+    def github.issue(_, _)
+      { "milestone" => { "number" => 123, "title" => "v1.0" } }
+    end
+    define_method github.update_issue(_, _, options)
+      set = true
+    end
+    tickets = Object.new
+    def tickets.submit(puzzle)
+      { number: '123', href: 'http://0pdd.com' }
+    end
+    test = MilestoneTickets.new('yegor256/0pdd', sources, github, tickets)
+    test.submit(
+      Nokogiri::XML(
+        '<puzzle>
+          <id>23-ab536de</id>
+          <file>/a/b/c/test.txt</file>
+          <time>01-01-2017</time>
+          <author>yegor</author>
+          <body>привет дорогой друг, как твои дела?</body>
+          <ticket>123</ticket>
+          <estimate>30</estimate>
+          <role>DEV</role>
+          <lines>1-3</lines>
+        </puzzle>'
+      ).xpath('/puzzle')
+    )
+    assert_equal(false, set)
+  end
+  
+  def test_adds_comment
+    sources = Object.new
+    def sources.config
+      YAML.safe_load(
+        "
+tickets:
+  - inherit-milestone
+"
+      )
+    end
+    github = FakeGithub.new
+    def github.issue(_, _)
+      { "milestone" => { "number" => 123, "title" => "v1.0" } }
+    end
+    def github.update_issue(_, _, options)
+      # do nothing
+    end
+    def github.add_comment(repo, issue, text)
+      @comment = text
+    end
+    class << github
+      attr_accessor :comment
+    end
+    tickets = Object.new
+    def tickets.submit(puzzle)
+      { number: '123', href: 'http://0pdd.com' }
+    end
+    test = MilestoneTickets.new('yegor256/0pdd', sources, github, tickets)
+    test.submit(
+      Nokogiri::XML(
+        '<puzzle>
+          <id>23-ab536de</id>
+          <file>/a/b/c/test.txt</file>
+          <time>01-01-2017</time>
+          <author>yegor</author>
+          <body>привет дорогой друг, как твои дела?</body>
+          <ticket>123</ticket>
+          <estimate>30</estimate>
+          <role>DEV</role>
+          <lines>1-3</lines>
+        </puzzle>'
+      ).xpath('/puzzle')
+    )
+    assert(github.comment.starts_with?('This puzzle inherited milestone'))
+  end
+end

--- a/test/test_milestone_tickets.rb
+++ b/test/test_milestone_tickets.rb
@@ -46,8 +46,9 @@ alerts:
     end
     github = FakeGithub.new
     def github.issue(_, _)
-      { "milestone" => { "number" => 123, "title" => "v1.0" } }
+      { 'milestone' => { 'number' => 123, 'title' => 'v1.0' } }
     end
+
     def github.update_issue(_, _, options)
       @milestone = options[:milestone]
     end
@@ -55,7 +56,7 @@ alerts:
       attr_accessor :milestone
     end
     tickets = Object.new
-    def tickets.submit(puzzle)
+    def tickets.submit(_)
       { number: 456, href: 'http://0pdd.com' }
     end
     test = MilestoneTickets.new('yegor256/0pdd', sources, github, tickets)
@@ -76,29 +77,31 @@ alerts:
     )
     assert_equal(milestone, github.milestone)
   end
-  
+
   def test_does_not_set_milestone
     sources = Object.new
     def sources.config
-      YAML.safe_load("
+      YAML.safe_load(
+        '
 alerts:
   suppress:
     - on-inherited-milestone
-    "
-    )
+    '
+      )
     end
     github = FakeGithub.new
     def github.issue(_, _)
-      { "milestone" => { "number" => 123, "title" => "v1.0" } }
+      { 'milestone' => { 'number' => 123, 'title' => 'v1.0' } }
     end
-    def github.update_issue(_, _, options)
+
+    def github.update_issue(_, _, _)
       @updated = true
     end
     class << github
       attr_accessor :updated
     end
     tickets = Object.new
-    def tickets.submit(puzzle)
+    def tickets.submit(_)
       { number: 123, href: 'http://0pdd.com' }
     end
     test = MilestoneTickets.new('yegor256/0pdd', sources, github, tickets)
@@ -117,34 +120,36 @@ alerts:
         </puzzle>'
       ).xpath('/puzzle')
     )
-    assert(not(github.updated))
+    assert(!github.updated)
   end
-  
+
   def test_adds_comment
     sources = Object.new
     def sources.config
       YAML.safe_load(
-        "
+        '
 tickets:
   - inherit-milestone
-"
+'
       )
     end
     github = FakeGithub.new
     def github.issue(_, _)
-      { "milestone" => { "number" => 123, "title" => "v1.0" } }
+      { 'milestone' => { 'number' => 123, 'title' => 'v1.0' } }
     end
-    def github.update_issue(_, _, options)
+
+    def github.update_issue(_, _, _)
       # do nothing
     end
-    def github.add_comment(repo, issue, text)
+
+    def github.add_comment(_, _, text)
       @comment = text
     end
     class << github
       attr_accessor :comment
     end
     tickets = Object.new
-    def tickets.submit(puzzle)
+    def tickets.submit(_)
       { number: 123, href: 'http://0pdd.com' }
     end
     test = MilestoneTickets.new('yegor256/0pdd', sources, github, tickets)
@@ -166,4 +171,3 @@ tickets:
     assert(github.comment.start_with?('This puzzle inherited milestone'))
   end
 end
-

--- a/test/test_milestone_tickets.rb
+++ b/test/test_milestone_tickets.rb
@@ -31,7 +31,7 @@ require_relative '../objects/milestone_tickets'
 # License:: MIT
 class TestGithubTickets < Test::Unit::TestCase
   def test_sets_milestone
-    MILESTONE_NUM = 123
+    milestone = 123
     sources = Object.new
     def sources.config
       YAML.safe_load(
@@ -46,7 +46,7 @@ alerts:
     end
     github = FakeGithub.new
     def github.issue(_, _)
-      { "milestone" => { "number" => MILESTONE_NUM, "title" => "v1.0" } }
+      { "milestone" => { "number" => milestone, "title" => "v1.0" } }
     end
     def github.update_issue(_, _, options)
       @milestone = options['milestone']
@@ -74,7 +74,7 @@ alerts:
         </puzzle>'
       ).xpath('/puzzle')
     )
-    assert_equal(MILESTONE_NUM, github.milestone)
+    assert_equal(milestone, github.milestone)
   end
   
   def test_does_not_set_milestone
@@ -112,7 +112,7 @@ alerts:
         </puzzle>'
       ).xpath('/puzzle')
     )
-    assert(not github.updated?)
+    assert(not(github.updated?))
   end
   
   def test_adds_comment

--- a/test/test_milestone_tickets.rb
+++ b/test/test_milestone_tickets.rb
@@ -56,7 +56,7 @@ alerts:
     end
     tickets = Object.new
     def tickets.submit(puzzle)
-      { number: '123', href: 'http://0pdd.com' }
+      { number: 123, href: 'http://0pdd.com' }
     end
     test = MilestoneTickets.new('yegor256/0pdd', sources, github, tickets)
     test.submit(
@@ -140,7 +140,7 @@ tickets:
     end
     tickets = Object.new
     def tickets.submit(puzzle)
-      { number: '123', href: 'http://0pdd.com' }
+      { number: 123, href: 'http://0pdd.com' }
     end
     test = MilestoneTickets.new('yegor256/0pdd', sources, github, tickets)
     test.submit(


### PR DESCRIPTION
This PR is for #174: **Inherit milestone from issue**
* Adds new `MilestoneTickets`
* Adds new configuration options for `.0pdd`:
```yaml
alerts:
  suppress:
    - on-inherited-milestone
tickets:
  - inherit-milestone
```

The presence of `tickets.inherit-milestone` activates `MilestoneTickets`.

The presence of `alerts.suppress.on-inherited-milestone` instructs `MilestoneTickets` *not* to add a comment on the new issue.