### PR TITLE
[#319] fetch all remotes before resetting head

### DIFF
--- a/objects/git_repo.rb
+++ b/objects/git_repo.rb
@@ -100,9 +100,9 @@ class GitRepo
         "cd #{@path}",
         "master=#{Shellwords.escape(@master)}",
         'git config --local core.autocrlf false',
-        'git reset origin/${master} --hard --quiet',
+        'git fetch --force --all --quiet',
+        'git reset --hard --quiet origin/${master}',
         'git clean --force -d',
-        'git fetch --quiet',
         'git checkout origin/${master}',
         'git rebase --abort || true',
         'git rebase --autostash --strategy-option=theirs origin/${master}'


### PR DESCRIPTION
This PR fixes `fatal: ambiguous argument '{remote}/{branch}': unknown revision or path not in the working tree`