### PR TITLE
[30] Show total repositories count

### DIFF
--- a/views/index.haml
+++ b/views/index.haml
@@ -13,6 +13,8 @@
       - tail.each_with_index do |r, i|
         %span
           %a{href:'https://github.com/' + r}>= r
+    %p
+      Total projects using 0pdd: tail.value
   %p
     Made by
     %a{href:'https://www.yegor256.com'} @yegor256

--- a/views/index.haml
+++ b/views/index.haml
@@ -10,7 +10,7 @@
     %p
       Recent commits:
       %br
-      - tail.each_with_index do |r, i|
+      - tail.each_with_index do |r|
         %span
           %a{href:'https://github.com/' + r}>= r
     %p


### PR DESCRIPTION
The current home page looks like the following way
We can mention that `Recent commits:` bock contains links to github repos rather than commits actually...
```
PDD puzzles collector.

[How does it work?](http://www.yegor256.com/2017/04/05/pdd-in-action.html)

Recent commits:
...

Made by [@yegor256](https://www.yegor256.com/) for [Zerocracy](https://www.zerocracy.com/)[](https://www.sixnines.io/h/574a)[](https://www.rehttp.net/i?u=http%3A%2F%2Fwww.0pdd.com%2Fhook%2Fgithub)[](https://github.com/yegor256/0pdd).

Currently deployed version 0.30.26 Git version on the server 2.17.1 Ruby version on the server 2.6.0

4998
```


So we can just add size of list that contains links to the `.haml` source script.