### PR TITLE
[#537] Accept push from master branch only

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,8 @@ Metrics/MethodLength:
   Max: 50
 Metrics/ClassLength:
   Max: 200
+  Exclude:
+    - "test/test_*.rb"
 Metrics/AbcSize:
   Max: 60
 Metrics/BlockLength:

--- a/0pdd.rb
+++ b/0pdd.rb
@@ -364,10 +364,12 @@ post '/hook/github' do
   github = GithubRepo.new(settings.github, json, settings.config)
   return [400, "No access to #{github.repo.name}"] unless github.exists?
   unless ENV['RACK_ENV'] == 'test'
-    process_request(github)
-    puts "GitHub hook from #{github.repo.name}"
+    process_request(github) if github.repo.change_in_master?
+    puts "GitHub hook from #{github.repo.name} to branch #{github.repo.target}"
   end
-  "Thanks #{github.repo.name}"
+  ignore = github.repo.change_in_master? ?
+             "Push is not to master branch, nothing is done. " : ''
+  "#{ignore}Thanks #{github.repo.name}"
 end
 
 get '/hook/gitlab' do
@@ -398,10 +400,12 @@ post '/hook/gitlab' do
   gitlab = GitlabRepo.new(settings.gitlab, json, settings.config)
   return [400, "No access to #{gitlab.repo.name}"] unless gitlab.exists?
   unless ENV['RACK_ENV'] == 'test'
-    process_request(gitlab)
-    puts "Gitlab hook from #{gitlab.repo.name}"
+    process_request(gitlab) if gitlab.repo.change_in_master?
+    puts "Gitlab hook from #{gitlab.repo.name} to branch #{gitlab.repo.target}"
   end
-  "Thanks #{gitlab.repo.name}"
+  ignore = github.repo.change_in_master? ?
+             "Push is not to master branch, nothing is done. " : ''
+  "#{ignore}Thanks #{gitlab.repo.name}"
 end
 
 get '/css/*.css' do

--- a/0pdd.rb
+++ b/0pdd.rb
@@ -367,8 +367,8 @@ post '/hook/github' do
     process_request(github) if github.repo.change_in_master?
     puts "GitHub hook from #{github.repo.name} to branch #{github.repo.target}"
   end
-  ignore = github.repo.change_in_master? ?
-             "Push is not to master branch, nothing is done. " : ''
+  ignore = ''
+  ignore = 'Push is not to master branch, nothing is done. ' unless github.repo.change_in_master?
   "#{ignore}Thanks #{github.repo.name}"
 end
 
@@ -403,8 +403,8 @@ post '/hook/gitlab' do
     process_request(gitlab) if gitlab.repo.change_in_master?
     puts "Gitlab hook from #{gitlab.repo.name} to branch #{gitlab.repo.target}"
   end
-  ignore = github.repo.change_in_master? ?
-             "Push is not to master branch, nothing is done. " : ''
+  ignore = ''
+  ignore = 'Push is not to master branch, nothing is done. ' unless gitlab.repo.change_in_master?
   "#{ignore}Thanks #{gitlab.repo.name}"
 end
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ to your repository, if it's private
 Then, add a `@todo` [puzzle](https://www.yegor256.com/2009/03/04/pdd.html)
 to the source code (format it [right](https://github.com/teamed/pdd)).
 
-Then, `git push` something and see what happens. You should see a new
+Then, `git push` to master branch something and see what happens. You should see a new
 issue created in your repository by [@0pdd](https://github.com/0pdd).
 
 The dependency tree of all puzzles in your repository you can find

--- a/objects/git_repo.rb
+++ b/objects/git_repo.rb
@@ -37,7 +37,6 @@ class GitRepo
   def initialize(
     uri:,
     name:,
-    target: 'master',
     master: 'master',
     head_commit_hash: '',
     **options
@@ -50,7 +49,7 @@ class GitRepo
     @id_rsa = options[:id_rsa] || ''
     @master = master
     @head_commit_hash = head_commit_hash
-    @target = target
+    @target = options[:target] || 'master'
   end
 
   def lock

--- a/objects/git_repo.rb
+++ b/objects/git_repo.rb
@@ -32,11 +32,12 @@ require_relative 'user_error'
 # Repository in Git
 #
 class GitRepo
-  attr_reader :uri, :name, :path, :master, :head_commit_hash
+  attr_reader :uri, :name, :path, :master, :head_commit_hash, :target
 
   def initialize(
     uri:,
     name:,
+    target: 'master',
     master: 'master',
     head_commit_hash: '',
     **options
@@ -49,6 +50,7 @@ class GitRepo
     @id_rsa = options[:id_rsa] || ''
     @master = master
     @head_commit_hash = head_commit_hash
+    @target = target
   end
 
   def lock
@@ -83,6 +85,10 @@ class GitRepo
     else
       clone
     end
+  end
+
+  def change_in_master?
+    "refs/heads/#{master}".eql?(target)
   end
 
   private

--- a/objects/vcs/github.rb
+++ b/objects/vcs/github.rb
@@ -140,12 +140,14 @@ class GithubRepo
 
   def git_repo(json, config)
     uri = json['repository']['ssh_url'] || json['repository']['url']
+    target = json['ref']
     name = json['repository']['full_name']
     default_branch = json['repository']['master_branch']
     head_commit_hash = json['head_commit'] ? json['head_commit']['id'] : ''
     GitRepo.new(
       uri: uri,
       name: name,
+      target: target,
       id_rsa: config['id_rsa'],
       master: default_branch,
       head_commit_hash: head_commit_hash

--- a/objects/vcs/github.rb
+++ b/objects/vcs/github.rb
@@ -147,8 +147,8 @@ class GithubRepo
     GitRepo.new(
       uri: uri,
       name: name,
-      target: target,
       id_rsa: config['id_rsa'],
+      target: target,
       master: default_branch,
       head_commit_hash: head_commit_hash
     )

--- a/objects/vcs/gitlab.rb
+++ b/objects/vcs/gitlab.rb
@@ -174,11 +174,13 @@ class GitlabRepo
   def git_repo(json, config)
     uri = json['project']['url']
     name = json['project']['path_with_namespace']
+    target = json['ref']
     default_branch = json['project']['default_branch']
     head_commit_hash = json['checkout_sha']
     GitRepo.new(
       uri: uri,
       name: name,
+      target: target,
       id_rsa: config['id_rsa'],
       master: default_branch,
       head_commit_hash: head_commit_hash

--- a/test/fake_gitlab.rb
+++ b/test/fake_gitlab.rb
@@ -24,6 +24,7 @@ class FakeGitlab
   def initialize(options = {})
     @name = 'GITLAB'
     @repositories = options[:repositories] || []
+    @projects = options[:projects] || []
     @repo = options[:repo]
   end
 
@@ -97,6 +98,12 @@ class FakeGitlab
   def star; end
 
   def repository(_ = nil)
+    {
+      private: false
+    }
+  end
+
+  def project(_ = nil)
     {
       private: false
     }

--- a/test/test_0pdd.rb
+++ b/test/test_0pdd.rb
@@ -101,10 +101,10 @@ class AppTest < Test::Unit::TestCase
     }
     post(
       '/hook/github',
-      %w[{"head_commit":{"id":"-"},
-        "repository":{"url":"localhost",
-          "full_name":"yegor256-one/com.github.0pdd-test"},
-        "ref":"refs/heads/master"}].join,
+      ['{"head_commit":{"id":"-"},',
+       '"repository":{"url":"localhost",',
+       '"full_name":"yegor256-one/com.github.0pdd-test"},',
+       '"ref":"refs/heads/master"}'].join,
       headers
     )
     assert(last_response.ok?)
@@ -119,10 +119,10 @@ class AppTest < Test::Unit::TestCase
     }
     post(
       '/hook/github',
-      %w[{"head_commit":{"id":"-"},
-          "repository":{"url":"localhost",
-          "full_name":"yegor256-one/com.github.0pdd-test"},
-          "ref":"refs/heads/main"}].join,
+      ['{"head_commit":{"id":"-"},',
+       '"repository":{"url":"localhost",',
+       '"full_name":"yegor256-one/com.github.0pdd-test"},',
+       '"ref":"refs/heads/main"}'].join,
       headers
     )
     assert(last_response.ok?)
@@ -138,11 +138,11 @@ class AppTest < Test::Unit::TestCase
     }
     post(
       '/hook/github',
-      %w[{"head_commit":{"id":"-"},
-          "repository":{"url":"localhost",
-          "master_branch":"main",
-          "full_name":"yegor256-one/com.github.0pdd-test"},
-          "ref":"refs/heads/main"}].join,
+      ['{"head_commit":{"id":"-"},',
+       '"repository":{"url":"localhost",',
+       '"master_branch": "main",',
+       '"full_name":"yegor256-one/com.github.0pdd-test"},',
+       '"ref":"refs/heads/main"}'].join,
       headers
     )
     assert(last_response.ok?)
@@ -158,11 +158,11 @@ class AppTest < Test::Unit::TestCase
     }
     post(
       '/hook/github',
-      %w[{"head_commit":{"id":"-"},
-          "repository":{"url":"localhost",
-          "master_branch":"main",
-          "full_name":"yegor256-one/com.github.0pdd-test"},
-          "ref":"refs/heads/master"}].join,
+      ['{"head_commit":{"id":"-"},',
+       '"repository":{"url":"localhost",',
+       '"master_branch": "main",',
+       '"full_name":"yegor256-one/com.github.0pdd-test"},',
+       '"ref":"refs/heads/master"}'].join,
       headers
     )
     assert(last_response.ok?)
@@ -173,15 +173,15 @@ class AppTest < Test::Unit::TestCase
   def test_it_understands_push_from_gitlab
     headers = {
       'CONTENT_TYPE' => 'application/json',
-      'X-Gitlab-Event' => 'Push Hook'
+      'HTTP_USER_AGENT' => 'GitLab 16.6',
+      'HTTP_X_GITLAB_EVENT' => 'Push Hook'
     }
     post(
-      '/hook/github',
-      %w[{"head_commit":{"id":"-"},
-        "checkout_sha": "da156088",
-        "project":{"url":"localhost",
-        "path_with_namespace":"yegor256-one/com.github.0pdd-test"},
-        "ref":"refs/heads/master"}].join,
+      '/hook/gitlab',
+      ['{"checkout_sha": "da1560886d4",',
+       '"project":{"url":"localhost",',
+       '"path_with_namespace":"yegor256-one/com.github.0pdd-test"},',
+       '"ref":"refs/heads/master"}'].join,
       headers
     )
     assert(last_response.ok?)
@@ -191,15 +191,15 @@ class AppTest < Test::Unit::TestCase
   def test_it_ignores_push_from_gitlab_to_not_master
     headers = {
       'CONTENT_TYPE' => 'application/json',
-      'X-Gitlab-Event' => 'Push Hook'
+      'HTTP_USER_AGENT' => 'GitLab 16.6',
+      'HTTP_X_GITLAB_EVENT' => 'Push Hook'
     }
     post(
-      '/hook/github',
-      %w[{"head_commit":{"id":"-"},
-          "checkout_sha": "da156088",
-          "repository":{"url":"localhost",
-          "path_with_namespace":"yegor256-one/com.github.0pdd-test"},
-          "ref":"refs/heads/main"}].join,
+      '/hook/gitlab',
+      ['{"checkout_sha": "da1560886d4",',
+       '"project":{"url":"localhost",',
+       '"path_with_namespace":"yegor256-one/com.github.0pdd-test"},',
+       '"ref":"refs/heads/main"}'].join,
       headers
     )
     assert(last_response.ok?)
@@ -210,36 +210,36 @@ class AppTest < Test::Unit::TestCase
   def test_it_accepts_push_from_gitlab_to_not_default_master
     headers = {
       'CONTENT_TYPE' => 'application/json',
-      'X-Gitlab-Event' => 'Push Hook'
+      'HTTP_USER_AGENT' => 'GitLab 16.6',
+      'HTTP_X_GITLAB_EVENT' => 'Push Hook'
     }
     post(
-      '/hook/github',
-      %w[{"head_commit":{"id":"-"},
-          "checkout_sha": "da156088",
-          "repository":{"url":"localhost",
-          "default_branch":"main",
-          "path_with_namespace":"yegor256-one/com.github.0pdd-test"},
-          "ref":"refs/heads/main"}].join,
+      '/hook/gitlab',
+      ['{"checkout_sha": "da1560886d4",',
+       '"project":{"url":"localhost",',
+       '"default_branch": "main",',
+       '"path_with_namespace":"yegor256-one/com.github.0pdd-test"},',
+       '"ref":"refs/heads/main"}'].join,
       headers
     )
     assert(last_response.ok?)
-    assert(last_response.body.include?('Thanks'))
+    assert(last_response.body.start_with?('Thanks'))
     assert(!last_response.body.include?('nothing is done'))
   end
 
   def test_it_ignores_push_from_gitlab_to_not_default_master
     headers = {
       'CONTENT_TYPE' => 'application/json',
-      'X-Gitlab-Event' => 'Push Hook'
+      'HTTP_USER_AGENT' => 'GitLab 16.6',
+      'HTTP_X_GITLAB_EVENT' => 'Push Hook'
     }
     post(
-      '/hook/github',
-      %w[{"head_commit":{"id":"-"},
-          "checkout_sha": "da156088",
-          "repository":{"url":"localhost",
-          "default_branch":"main",
-          "path_with_namespace":"yegor256-one/com.github.0pdd-test"},
-          "ref":"refs/heads/master"}].join,
+      '/hook/gitlab',
+      ['{"checkout_sha": "da1560886d4",',
+       '"project":{"url":"localhost",',
+       '"default_branch": "main",',
+       '"path_with_namespace":"yegor256-one/com.github.0pdd-test"},',
+       '"ref":"refs/heads/master"}'].join,
       headers
     )
     assert(last_response.ok?)

--- a/test/test_0pdd.rb
+++ b/test/test_0pdd.rb
@@ -101,16 +101,150 @@ class AppTest < Test::Unit::TestCase
     }
     post(
       '/hook/github',
-      [
-        '{"head_commit":{"id":"-"},',
-        '"repository":{"url":"localhost",',
-        '"full_name":"yegor256-one/com.github.0pdd-test"},',
-        '"ref":"refs/heads/master"}'
-      ].join,
+      %w[{"head_commit":{"id":"-"},
+        "repository":{"url":"localhost",
+          "full_name":"yegor256-one/com.github.0pdd-test"},
+        "ref":"refs/heads/master"}].join,
       headers
     )
     assert(last_response.ok?)
     assert(last_response.body.include?('Thanks'))
+  end
+
+  def test_it_ignores_push_from_github_to_not_master
+    headers = {
+      'CONTENT_TYPE' => 'application/json',
+      'HTTP_USER_AGENT' => 'GitHub-Hookshot',
+      'HTTP_X_GITHUB_EVENT' => 'push'
+    }
+    post(
+      '/hook/github',
+      %w[{"head_commit":{"id":"-"},
+          "repository":{"url":"localhost",
+          "full_name":"yegor256-one/com.github.0pdd-test"},
+          "ref":"refs/heads/main"}].join,
+      headers
+    )
+    assert(last_response.ok?)
+    assert(last_response.body.include?('Thanks'))
+    assert(last_response.body.include?('nothing is done'))
+  end
+
+  def test_it_accepts_push_from_github_to_not_default_master
+    headers = {
+      'CONTENT_TYPE' => 'application/json',
+      'HTTP_USER_AGENT' => 'GitHub-Hookshot',
+      'HTTP_X_GITHUB_EVENT' => 'push'
+    }
+    post(
+      '/hook/github',
+      %w[{"head_commit":{"id":"-"},
+          "repository":{"url":"localhost",
+          "master_branch":"main",
+          "full_name":"yegor256-one/com.github.0pdd-test"},
+          "ref":"refs/heads/main"}].join,
+      headers
+    )
+    assert(last_response.ok?)
+    assert(last_response.body.include?('Thanks'))
+    assert(!last_response.body.include?('nothing is done'))
+  end
+
+  def test_it_ignore_push_from_github_to_not_default_master
+    headers = {
+      'CONTENT_TYPE' => 'application/json',
+      'HTTP_USER_AGENT' => 'GitHub-Hookshot',
+      'HTTP_X_GITHUB_EVENT' => 'push'
+    }
+    post(
+      '/hook/github',
+      %w[{"head_commit":{"id":"-"},
+          "repository":{"url":"localhost",
+          "master_branch":"main",
+          "full_name":"yegor256-one/com.github.0pdd-test"},
+          "ref":"refs/heads/master"}].join,
+      headers
+    )
+    assert(last_response.ok?)
+    assert(last_response.body.include?('Thanks'))
+    assert(last_response.body.include?('nothing is done'))
+  end
+
+  def test_it_understands_push_from_gitlab
+    headers = {
+      'CONTENT_TYPE' => 'application/json',
+      'X-Gitlab-Event' => 'Push Hook'
+    }
+    post(
+      '/hook/github',
+      %w[{"head_commit":{"id":"-"},
+        "checkout_sha": "da156088",
+        "project":{"url":"localhost",
+        "path_with_namespace":"yegor256-one/com.github.0pdd-test"},
+        "ref":"refs/heads/master"}].join,
+      headers
+    )
+    assert(last_response.ok?)
+    assert(last_response.body.include?('Thanks'))
+  end
+
+  def test_it_ignores_push_from_gitlab_to_not_master
+    headers = {
+      'CONTENT_TYPE' => 'application/json',
+      'X-Gitlab-Event' => 'Push Hook'
+    }
+    post(
+      '/hook/github',
+      %w[{"head_commit":{"id":"-"},
+          "checkout_sha": "da156088",
+          "repository":{"url":"localhost",
+          "path_with_namespace":"yegor256-one/com.github.0pdd-test"},
+          "ref":"refs/heads/main"}].join,
+      headers
+    )
+    assert(last_response.ok?)
+    assert(last_response.body.include?('Thanks'))
+    assert(last_response.body.include?('nothing is done'))
+  end
+
+  def test_it_accepts_push_from_gitlab_to_not_default_master
+    headers = {
+      'CONTENT_TYPE' => 'application/json',
+      'X-Gitlab-Event' => 'Push Hook'
+    }
+    post(
+      '/hook/github',
+      %w[{"head_commit":{"id":"-"},
+          "checkout_sha": "da156088",
+          "repository":{"url":"localhost",
+          "default_branch":"main",
+          "path_with_namespace":"yegor256-one/com.github.0pdd-test"},
+          "ref":"refs/heads/main"}].join,
+      headers
+    )
+    assert(last_response.ok?)
+    assert(last_response.body.include?('Thanks'))
+    assert(!last_response.body.include?('nothing is done'))
+  end
+
+  def test_it_ignores_push_from_gitlab_to_not_default_master
+    headers = {
+      'CONTENT_TYPE' => 'application/json',
+      'X-Gitlab-Event' => 'Push Hook'
+    }
+    post(
+      '/hook/github',
+      %w[{"head_commit":{"id":"-"},
+          "checkout_sha": "da156088",
+          "repository":{"url":"localhost",
+          "default_branch":"main",
+          "path_with_namespace":"yegor256-one/com.github.0pdd-test"},
+          "ref":"refs/heads/master"}].join,
+      headers
+    )
+    assert(last_response.ok?)
+    assert(last_response.body.include?('Thanks'))
+    assert(last_response.body.include?('nothing is done'))
   end
 
   def test_renders_html_puzzles


### PR DESCRIPTION
1. Run processing only for master branch (for GitHub master_branch, for Gitlab default_branch)
2. Add tests for gitlab 