### PR TITLE
#852 rescue ping GitHub Octokit errors

### DIFF
--- a/0pdd.rb
+++ b/0pdd.rb
@@ -314,15 +314,17 @@ get '/ping-github' do
           )
           puts "Replied to #{repo}##{issue}"
         end
-      rescue Octokit::NotFound => e
+      rescue Octokit::Error => e
         puts "Failed: #{e.message}"
-        next
       end
     end
     "#{repo}: #{reason}"
   end
   gh.mark_notifications_as_read(last_read_at: Time.now)
   "#{msgs.join("\n")}\n"
+rescue Octokit::Error => e
+  puts "Failed to ping GitHub: #{e.message}"
+  "Failed: #{e.message}\n"
 end
 
 get '/hook/github' do

--- a/test/fake_github.rb
+++ b/test/fake_github.rb
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 class FakeGithub
-  attr_reader :name, :repo
+  attr_reader :comments, :name, :notifications_read, :repo
 
   def initialize(options = {})
     @name = 'GITHUB'
@@ -33,10 +33,29 @@ class FakeGithub
       }
     ]
     @repositories = options[:repositories] || []
+    @comments = []
+    @notifications = options[:notifications] || [
+      {
+        'reason' => 'mention',
+        'repository' => {
+          'full_name' => 'yegor256/0pdd'
+        },
+        'subject' => {
+          'type' => 'Issue',
+          'url' => 'https://api.github.com/repos/yegor256/0pdd/issues/852',
+          'latest_comment_url' => 'https://api.github.com/repos/yegor256/0pdd/issues/comments/123'
+        },
+        'updated_at' => '2026-05-26T00:00:00Z'
+      }
+    ]
+    @errors = options[:errors] || {}
+    @notifications_read = nil
     @repo = options[:repo]
   end
 
   def rate_limit
+    raise @errors[:rate_limit] if @errors[:rate_limit]
+
     limit = Object.new
 
     def limit.remaining
@@ -58,6 +77,27 @@ class FakeGithub
     else
       @memberships
     end
+  end
+
+  def notifications
+    raise @errors[:notifications] if @errors[:notifications]
+
+    @notifications
+  end
+
+  def issue_comment(_repo, _comment)
+    raise @errors[:issue_comment] if @errors[:issue_comment]
+
+    {
+      'body' => '@0pdd please help',
+      'user' => {
+        'login' => 'yegor256'
+      }
+    }
+  end
+
+  def login
+    '0pdd'
   end
 
   def user_repository_invitations(_options = {})
@@ -114,7 +154,24 @@ class FakeGithub
 
   def add_labels_to_an_issue(_, _); end
 
-  def add_comment(_, _); end
+  def add_comment(*args)
+    repo, issue, body = if args.length == 3
+      args
+    else
+      [@repo&.name, args[0], args[1]]
+    end
+    @comments << {
+      repo: repo,
+      issue: issue,
+      body: body
+    }
+  end
+
+  def mark_notifications_as_read(options = {})
+    raise @errors[:mark_notifications_as_read] if @errors[:mark_notifications_as_read]
+
+    @notifications_read = options
+  end
 
   def create_commit_comment(_, _, _)
     {

--- a/test/test_0pdd.rb
+++ b/test/test_0pdd.rb
@@ -265,6 +265,24 @@ class AppTest < Minitest::Test
     )
   end
 
+  def test_ping_github_continues_after_comment_error
+    github = FakeGithub.new(errors: { issue_comment: Octokit::Error.new })
+    Sinatra::Application.set(:github, github)
+    get('/ping-github')
+    assert_predicate(last_response, :ok?, last_response.body)
+    assert_includes(last_response.body, 'yegor256/0pdd: mention')
+    refute_nil(github.notifications_read)
+  end
+
+  def test_ping_github_survives_notification_error
+    github = FakeGithub.new(errors: { notifications: Octokit::Error.new })
+    Sinatra::Application.set(:github, github)
+    get('/ping-github')
+    assert_predicate(last_response, :ok?, last_response.body)
+    assert_includes(last_response.body, 'Failed: Octokit::Error')
+    assert_nil(github.notifications_read)
+  end
+
   def test_rejects_invalid_repo_name
     get('/svg?name=yego256/pdd+a')
     refute_predicate(last_response, :ok?)


### PR DESCRIPTION
Addresses #852.

What changed:
- rescue broader `Octokit::Error` failures while processing mention notifications, so one bad comment lookup or reply no longer aborts the full notification loop
- rescue route-level GitHub API failures around rate-limit, invitation, notification, and mark-read calls so `/ping-github` returns a plain failure message instead of surfacing a 500
- extend `FakeGithub` and add focused regression coverage for comment and notification failures

Validation:
- `ruby -c 0pdd.rb; ruby -c test\fake_github.rb; ruby -c test\test_0pdd.rb`
- `rubocop 0pdd.rb test/fake_github.rb test/test_0pdd.rb`
- focused tests with local stubs for unavailable Windows deps: `2 tests, 10 assertions, 0 failures, 0 errors, 0 skips`
- `git diff --check`
- `gitleaks dir --no-banner --redact --log-level error .`

Limitations:
- Full `bundle exec` validation was not possible on this Windows environment because `bundle install` failed while building native `openssl` and `ruby-filemagic` dependencies.