### PR TITLE
#853: wrap GitLab VCS failures

### DIFF
--- a/objects/vcs/gitlab.rb
+++ b/objects/vcs/gitlab.rb
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 require 'gitlab'
+require 'faraday'
 require 'net/http'
 require_relative '../git_repo'
 require_relative '../clients/gitlab'
@@ -13,8 +14,11 @@ require_relative '../clients/gitlab'
 class GitlabRepo
   ERRORS = [
     Gitlab::Error::Error,
+    Faraday::Error,
     Net::OpenTimeout,
-    Errno::ECONNREFUSED
+    Net::ReadTimeout,
+    Errno::ECONNREFUSED,
+    SocketError
   ].freeze
 
   attr_reader :repo, :name
@@ -89,7 +93,7 @@ class GitlabRepo
   def add_comment(issue_id, comment)
     @client.create_issue_note(@repo.name, issue_id, comment)
   rescue *ERRORS => e
-    raise "Can't comment GitLab issue #{issue_id}: #{e.message}"
+    raise "Can't comment on GitLab issue #{issue_id}: #{e.message}"
   end
 
   def create_commit_comment(sha, comment)

--- a/objects/vcs/gitlab.rb
+++ b/objects/vcs/gitlab.rb
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 require 'gitlab'
+require 'net/http'
 require_relative '../git_repo'
 require_relative '../clients/gitlab'
 
@@ -10,6 +11,12 @@ require_relative '../clients/gitlab'
 # API: https://github.com/NARKOZ/gitlab
 #
 class GitlabRepo
+  ERRORS = [
+    Gitlab::Error::Error,
+    Net::OpenTimeout,
+    Errno::ECONNREFUSED
+  ].freeze
+
   attr_reader :repo, :name
 
   def initialize(client, json, config = {})
@@ -34,14 +41,14 @@ class GitlabRepo
         title: title
       }
     }
-  rescue Gitlab::Error::NotFound => e
-    raise "The issue most probably is not found, can' comment: #{e.message}"
+  rescue *ERRORS => e
+    raise "Can't read GitLab issue #{issue_id}: #{e.message}"
   end
 
   def close_issue(issue_id)
     @client.close_issue(@repo.name, issue_id)
-  rescue Gitlab::Error::NotFound => e
-    raise "The issue most probably is not found, can't close: #{e.message}"
+  rescue *ERRORS => e
+    raise "Can't close GitLab issue #{issue_id}: #{e.message}"
   end
 
   def create_issue(data)
@@ -81,8 +88,8 @@ class GitlabRepo
 
   def add_comment(issue_id, comment)
     @client.create_issue_note(@repo.name, issue_id, comment)
-  rescue Gitlab::Error::NotFound => e
-    raise "The issue most probably is not found, can't comment: #{e.message}"
+  rescue *ERRORS => e
+    raise "Can't comment GitLab issue #{issue_id}: #{e.message}"
   end
 
   def create_commit_comment(sha, comment)

--- a/test/test_gitlab.rb
+++ b/test/test_gitlab.rb
@@ -3,6 +3,7 @@
 
 require_relative 'test__helper'
 require_relative '../objects/clients/gitlab'
+require_relative '../objects/vcs/gitlab'
 
 # Github test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
@@ -14,5 +15,63 @@ class TestGitlab < Minitest::Test
     assert_raises Gitlab::Error::MissingCredentials do
       gitlab.user('0pdd')['username']
     end
+  end
+
+  def test_wraps_issue_read_errors
+    error = assert_raises(RuntimeError) do
+      gitlab_repo(client_raising(:issue, Gitlab::Error::Forbidden)).issue(42)
+    end
+    assert_includes(error.message, "Can't read GitLab issue 42:")
+    assert_includes(error.message, 'denied')
+  end
+
+  def test_wraps_issue_close_errors
+    error = assert_raises(RuntimeError) do
+      gitlab_repo(client_raising(:close_issue, Gitlab::Error::TooManyRequests)).close_issue(42)
+    end
+    assert_includes(error.message, "Can't close GitLab issue 42:")
+    assert_includes(error.message, 'denied')
+  end
+
+  def test_wraps_comment_errors
+    error = assert_raises(RuntimeError) do
+      gitlab_repo(client_raising(:create_issue_note, Net::OpenTimeout)).add_comment(42, 'hello')
+    end
+    assert_equal("Can't comment GitLab issue 42: denied", error.message)
+  end
+
+  private
+
+  def gitlab_repo(client)
+    GitlabRepo.new(
+      client,
+      {
+        'ref' => 'refs/heads/master',
+        'checkout_sha' => 'abcdef',
+        'project' => {
+          'url' => 'git@gitlab.com:yegor/0pdd.git',
+          'path_with_namespace' => 'yegor/0pdd',
+          'default_branch' => 'master'
+        }
+      }
+    )
+  end
+
+  def client_raising(method, error)
+    response = gitlab_response
+    Object.new.tap do |client|
+      client.define_singleton_method(method) do |_repo, *_args|
+        raise error.new(response) if error < Gitlab::Error::ResponseError # rubocop:disable Style/RaiseArgs
+        raise error, 'denied'
+      end
+    end
+  end
+
+  def gitlab_response
+    OpenStruct.new(
+      code: 403,
+      parsed_response: OpenStruct.new(message: 'denied'),
+      request: OpenStruct.new(base_uri: 'https://gitlab.com', path: '/api/v4/projects/1')
+    )
   end
 end

--- a/test/test_gitlab.rb
+++ b/test/test_gitlab.rb
@@ -37,7 +37,14 @@ class TestGitlab < Minitest::Test
     error = assert_raises(RuntimeError) do
       gitlab_repo(client_raising(:create_issue_note, Net::OpenTimeout)).add_comment(42, 'hello')
     end
-    assert_equal("Can't comment GitLab issue 42: denied", error.message)
+    assert_equal("Can't comment on GitLab issue 42: denied", error.message)
+  end
+
+  def test_wraps_comment_transport_errors
+    error = assert_raises(RuntimeError) do
+      gitlab_repo(client_raising(:create_issue_note, Faraday::ConnectionFailed)).add_comment(42, 'hello')
+    end
+    assert_equal("Can't comment on GitLab issue 42: denied", error.message)
   end
 
   private


### PR DESCRIPTION
Closes #853.

This PR updates `GitlabRepo` to wrap GitLab API failures raised by issue reads, close attempts, and comment creation. It covers the GitLab response errors from the ticket plus common transport failures, and it replaces the typoed `can' comment` read-error text with operation-specific wrapper messages.

What changed:
- widen `issue`, `close_issue`, and `add_comment` rescue handling from only `Gitlab::Error::NotFound` to GitLab API errors plus common transport failures
- cover `Faraday::Error`, `Net::OpenTimeout`, `Net::ReadTimeout`, `Errno::ECONNREFUSED`, and `SocketError` in the shared GitLab issue-operation rescue list
- add focused regressions for forbidden, rate-limit, timeout, and Faraday connection failures

Validation:
- `PICKS=1 bundle exec rake test TEST=test/test_gitlab.rb` in Docker Ruby 3.3 with `libmagic-dev`, Maven, and default JRE: 5 tests, 15 assertions, 0 failures, 0 errors, 0 skips
- `PICKS=1 bundle exec ruby -Itest test/test_gitlab.rb` in Docker Ruby 3.3: 5 tests, 15 assertions, 0 failures, 0 errors, 0 skips
- `bundle exec rubocop objects/vcs/gitlab.rb test/test_gitlab.rb`: 2 files inspected, no offenses detected
- `bundle exec rubocop`: 89 files inspected, no offenses detected
- `git diff --check`
- `gitleaks dir --no-banner --redact --log-level error .`
- GitHub Actions for this PR passed: actionlint, bashate, codecov, copyrights, markdown-lint, pdd, rake test, reuse, shellcheck, typos, xcop, yamllint, and Codacy

No secrets or credentials used.