### PR TITLE
#851: normalize Jira issue lookup

### DIFF
--- a/objects/tickets/tickets.rb
+++ b/objects/tickets/tickets.rb
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: MIT
 
 require 'haml'
+require 'jira-ruby'
+require 'gitlab'
+require 'octokit'
 require_relative '../truncated'
 require_relative '../maybe_text'
 
@@ -18,7 +21,7 @@ class Tickets
       issue,
       "@#{@vcs.issue(issue)[:author][:username]} #{message}"
     )
-  rescue Octokit::NotFound, Gitlab::NotFound, JIRA::NotFound => e
+  rescue JIRA::HTTPError, Octokit::NotFound, Gitlab::Error::NotFound => e
     puts "The issue most probably is not found, can't comment: #{e.message}"
   end
 

--- a/objects/vcs/jira.rb
+++ b/objects/vcs/jira.rb
@@ -19,7 +19,14 @@ class JiraRepo
   end
 
   def issue(issue_id)
-    @client.Issue.find(issue_id)
+    found = @client.Issue.find(issue_id)
+    {
+      state: issue_state(found),
+      author: issue_author(found),
+      milestone: nil
+    }
+  rescue JIRA::HTTPError => e
+    raise "Can't read JIRA issue #{issue_id}: #{e.message}"
   end
 
   def close_issue(issue_id)
@@ -72,6 +79,26 @@ class JiraRepo
   end
 
   private
+
+  def issue_state(issue)
+    status = issue_field(issue, 'status', 'statusCategory', 'key')
+    status == 'done' ? 'closed' : 'open'
+  end
+
+  def issue_author(issue)
+    reporter = issue_field(issue, 'reporter') || {}
+    {
+      id: reporter['accountId'] || reporter[:accountId],
+      username: reporter['name'] || reporter[:name] || reporter['displayName'] || reporter[:displayName]
+    }
+  end
+
+  def issue_field(issue, *keys)
+    keys.reduce(issue.fields) do |data, key|
+      break if data.nil?
+      data[key] || data[key.to_sym]
+    end
+  end
 
   def git_repo(json, config)
     uri = json['repository']['ssh_url'] || json['repository']['url']

--- a/test/test_jira.rb
+++ b/test/test_jira.rb
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'ostruct'
+require_relative 'test__helper'
+require_relative '../objects/tickets/tickets'
+require_relative '../objects/vcs/jira'
+
+# JiraRepo test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2016-2026 Yegor Bugayenko
+# License:: MIT
+class TestJira < Minitest::Test
+  def test_reads_issue_as_contract_hash
+    issue = jira_repo(
+      {
+        'status' => {
+          'statusCategory' => {
+            'key' => 'done'
+          }
+        },
+        'reporter' => {
+          'accountId' => 'abc',
+          'name' => 'yegor256',
+          'displayName' => 'Yegor Bugayenko'
+        }
+      }
+    ).issue('JRA-1')
+    assert_equal('closed', issue[:state])
+    assert_equal({ id: 'abc', username: 'yegor256' }, issue[:author])
+    assert_nil(issue[:milestone])
+  end
+
+  def test_reads_unfinished_issue_as_open
+    issue = jira_repo(
+      {
+        'status' => {
+          'statusCategory' => {
+            'key' => 'indeterminate'
+          }
+        }
+      }
+    ).issue('JRA-2')
+    assert_equal('open', issue[:state])
+  end
+
+  def test_wraps_http_error_on_issue_read
+    error = assert_raises(RuntimeError) do
+      jira_repo({}, error: jira_error('not accessible')).issue('JRA-3')
+    end
+    assert_equal("Can't read JIRA issue JRA-3: not accessible", error.message)
+  end
+
+  def test_notify_rescues_jira_http_errors
+    error = jira_error('gone')
+    vcs = Object.new
+    vcs.define_singleton_method(:issue) { |_issue| raise error }
+    vcs.define_singleton_method(:add_comment) do |_issue, _comment|
+      raise 'comment should not be posted'
+    end
+    stdout, = capture_io { Tickets.new(vcs).notify('JRA-4', 'please check') }
+    assert_includes(stdout, "can't comment: gone")
+  end
+
+  private
+
+  def jira_repo(fields, error: nil)
+    finder = Object.new
+    finder.define_singleton_method(:find) do |_issue|
+      raise error unless error.nil?
+      OpenStruct.new(fields: fields)
+    end
+    JiraRepo.new(jira_client(finder), jira_json)
+  end
+
+  def jira_client(finder)
+    Class.new do
+      def initialize(finder)
+        @finder = finder
+      end
+
+      def method_missing(name, *args)
+        return @finder if name == :Issue
+        super
+      end
+
+      def respond_to_missing?(name, include_private = false)
+        name == :Issue || super
+      end
+    end.new(finder)
+  end
+
+  def jira_json
+    {
+      'repository' => {
+        'ssh_url' => 'git@example.com:yegor256/0pdd.git',
+        'full_name' => 'yegor256/0pdd',
+        'master_branch' => 'master'
+      },
+      'head_commit' => {
+        'id' => 'abcdef'
+      }
+    }
+  end
+
+  def jira_error(message)
+    JIRA::HTTPError.new(OpenStruct.new(message: message, body: nil))
+  end
+end


### PR DESCRIPTION
Fixes #851

## Summary
- make `JiraRepo#issue` return the same `{ state:, author:, milestone: }` contract used by the GitHub and GitLab adapters
- map Jira done status categories to `closed`, keep other Jira statuses `open`, and preserve reporter identity in the author hash
- wrap `JIRA::HTTPError` from issue reads and let `Tickets#notify` handle Jira HTTP lookup failures cleanly

## Validation
- `PICKS=1 bundle exec ruby -Itest test/test_jira.rb` -> 4 tests, 8 assertions, 0 failures, 0 errors
- `PICKS=1 bundle exec rake test TEST=test/test_jira.rb` -> 4 tests, 8 assertions, 0 failures, 0 errors
- `bundle exec rubocop objects/vcs/jira.rb objects/tickets/tickets.rb test/test_jira.rb` -> 3 files inspected, no offenses
- `bundle exec rubocop` -> 90 files inspected, no offenses
- `git diff --check upstream/master...HEAD` -> passed
- `git diff --no-ext-diff upstream/master...HEAD | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found

No live Jira or 0pdd service calls were used; validation was local source/tests only.