### PR TITLE
#853: rescue GitLab issue operation errors

### DIFF
--- a/objects/vcs/gitlab.rb
+++ b/objects/vcs/gitlab.rb
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 require 'gitlab'
+require 'net/http'
 require_relative '../git_repo'
 require_relative '../clients/gitlab'
 
@@ -10,6 +11,12 @@ require_relative '../clients/gitlab'
 # API: https://github.com/NARKOZ/gitlab
 #
 class GitlabRepo
+  ISSUE_ERRORS = [
+    Gitlab::Error::Error,
+    Net::OpenTimeout,
+    Errno::ECONNREFUSED
+  ].freeze
+
   attr_reader :repo, :name
 
   def initialize(client, json, config = {})
@@ -34,14 +41,14 @@ class GitlabRepo
         title: title
       }
     }
-  rescue Gitlab::Error::NotFound => e
-    raise "The issue most probably is not found, can' comment: #{e.message}"
+  rescue *ISSUE_ERRORS => e
+    raise issue_error(issue_id, 'read', e)
   end
 
   def close_issue(issue_id)
     @client.close_issue(@repo.name, issue_id)
-  rescue Gitlab::Error::NotFound => e
-    raise "The issue most probably is not found, can't close: #{e.message}"
+  rescue *ISSUE_ERRORS => e
+    raise issue_error(issue_id, 'close', e)
   end
 
   def create_issue(data)
@@ -81,8 +88,8 @@ class GitlabRepo
 
   def add_comment(issue_id, comment)
     @client.create_issue_note(@repo.name, issue_id, comment)
-  rescue Gitlab::Error::NotFound => e
-    raise "The issue most probably is not found, can't comment: #{e.message}"
+  rescue *ISSUE_ERRORS => e
+    raise issue_error(issue_id, 'comment on', e)
   end
 
   def create_commit_comment(sha, comment)
@@ -153,6 +160,10 @@ class GitlabRepo
   end
 
   private
+
+  def issue_error(issue_id, action, cause)
+    "Can't #{action} GitLab issue #{issue_id}: #{cause.message}"
+  end
 
   def git_repo(json, config)
     uri = json['project']['url']

--- a/test/test_gitlab_repo.rb
+++ b/test/test_gitlab_repo.rb
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'test__helper'
+require_relative '../objects/vcs/gitlab'
+
+class TestGitlabRepo < Minitest::Test
+  def test_wraps_issue_lookup_gitlab_error
+    error = gitlab_response_error(Gitlab::Error::Forbidden, 403, 'forbidden')
+    raised = assert_raises(RuntimeError) do
+      repo_with_error(:issue, error).issue(42)
+    end
+    assert_includes raised.message, "Can't read GitLab issue 42"
+    assert_includes raised.message, 'forbidden'
+    refute_includes raised.message, "can' comment"
+  end
+
+  def test_wraps_close_issue_gitlab_error
+    error = gitlab_response_error(Gitlab::Error::TooManyRequests, 429, 'slow down')
+    raised = assert_raises(RuntimeError) do
+      repo_with_error(:close_issue, error).close_issue(42)
+    end
+    assert_includes raised.message, "Can't close GitLab issue 42"
+    assert_includes raised.message, 'slow down'
+  end
+
+  def test_wraps_add_comment_network_error
+    raised = assert_raises(RuntimeError) do
+      repo_with_error(:create_issue_note, Net::OpenTimeout.new('timed out')).add_comment(42, 'hello')
+    end
+    assert_includes raised.message, "Can't comment on GitLab issue 42"
+    assert_includes raised.message, 'timed out'
+  end
+
+  private
+
+  def repo_with_error(method, error)
+    GitlabRepo.new(FailingGitlabClient.new(method, error), gitlab_payload)
+  end
+
+  def gitlab_payload
+    {
+      'project' => {
+        'url' => 'https://gitlab.com/acme/widgets',
+        'path_with_namespace' => 'acme/widgets',
+        'default_branch' => 'master'
+      },
+      'ref' => 'master',
+      'checkout_sha' => 'abc123'
+    }
+  end
+
+  def gitlab_response_error(klass, code, message)
+    klass.new(GitlabErrorResponse.new(code, message))
+  end
+
+  class FailingGitlabClient
+    def initialize(method, error)
+      @method = method
+      @error = error
+    end
+
+    def issue(*)
+      raise @error if @method == :issue
+    end
+
+    def close_issue(*)
+      raise @error if @method == :close_issue
+    end
+
+    def create_issue_note(*)
+      raise @error if @method == :create_issue_note
+    end
+  end
+
+  class GitlabErrorResponse
+    attr_reader :code, :request
+
+    def initialize(code, message)
+      @code = code
+      @message = message
+      @request = OpenStruct.new(base_uri: 'https://gitlab.example', path: '/api/v4/projects/1')
+    end
+
+    def parsed_response
+      OpenStruct.new(message: @message)
+    end
+  end
+end


### PR DESCRIPTION
﻿## Summary
- Wrap GitLab issue read/close/comment operations in a stable 0pdd error message when the GitLab API raises `Gitlab::Error::Error` subclasses.
- Include common connection failures (`Net::OpenTimeout`, `Errno::ECONNREFUSED`) in the same wrapper path.
- Remove the old `can' comment` typo by using one shared issue-operation error formatter.

## Validation
- RED: `PICKS=1 ruby -Itest -Iobjects test/test_gitlab_repo.rb` failed against the old implementation: Forbidden and TooManyRequests propagated raw, and the network failure did not use the expected wrapper message.
- GREEN: `$env:PICKS='1'; ruby -Itest -Iobjects -e "`$LOADED_FEATURES << 'pdd.rb'; require './test/test_gitlab'; require './test/test_gitlab_repo'"` -> 4 tests, 18 assertions, 0 failures, 0 errors, 0 skips.
- `ruby -c objects\vcs\gitlab.rb; ruby -c test\test_gitlab_repo.rb`
- `rubocop objects\vcs\gitlab.rb test\test_gitlab_repo.rb --format simple`
- `git diff --cached --check`
- `git diff --cached | gitleaks detect --pipe --redact --no-banner --no-color --log-level error`

## Limitations
- Full local `bundle install` / rake is not claimed on this Windows machine because native `openssl` and `ruby-filemagic` extensions fail to build without local OpenSSL/libmagic headers and the MSYS keyring is not writable. The focused tests were run with `pdd.rb` pre-marked as loaded because this change does not exercise `GitRepo#xml`/PDD behavior.
