### PR TITLE
Handle VCS-specific log keys

### DIFF
--- a/objects/log.rb
+++ b/objects/log.rb
@@ -11,14 +11,18 @@ require_relative '../version'
 # Log.
 #
 class Log
+  SUPPORTED_VCS = %w[github gitlab].freeze
+
   def initialize(dynamo, repo, vcs = 'github')
     @dynamo = dynamo
-    # @todo #312:30min Be sure to handle the use case where projects from
-    #  different vcs have the same <user/repo_name>. This will cause a conflict.
-    @vcs = (vcs || 'github').downcase
-    @repo = @vcs == 'github' ? repo : Base64.encode64(repo + @vcs).gsub(%r{[\s=/]+}, '')
+    @vcs = (vcs || 'github').strip.downcase
+    raise 'You need to specify your cloud VCS' unless SUPPORTED_VCS.include?(@vcs)
 
-    raise 'You need to specify your cloud VCS' unless ['github'].include?(@vcs)
+    @repo = if @vcs == 'github'
+              repo
+            else
+              Base64.strict_encode64("#{@vcs}:#{repo}").delete('=')
+            end
   end
 
   def put(tag, text)

--- a/objects/vcs/gitlab.rb
+++ b/objects/vcs/gitlab.rb
@@ -13,7 +13,7 @@ class GitlabRepo
   attr_reader :repo, :name
 
   def initialize(client, json, config = {})
-    @name = 'github'
+    @name = 'gitlab'
     @client = client
     @config = config
     @json = json

--- a/test/test_gitlab_repo.rb
+++ b/test/test_gitlab_repo.rb
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'test__helper'
+require_relative '../objects/vcs/gitlab'
+
+# GitLab repo test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2016-2026 Yegor Bugayenko
+# License:: MIT
+class TestGitlabRepo < Minitest::Test
+  def test_identifies_vcs
+    repo = GitlabRepo.new(
+      nil,
+      {
+        'checkout_sha' => 'a1b2c3',
+        'project' => {
+          'url' => 'git@gitlab.com:yegor256/0pdd.git',
+          'path_with_namespace' => 'yegor256/0pdd',
+          'default_branch' => 'master'
+        },
+        'ref' => 'refs/heads/master'
+      }
+    )
+    assert_equal('gitlab', repo.name)
+  end
+end

--- a/test/test_log.rb
+++ b/test/test_log.rb
@@ -5,7 +5,26 @@ require 'nokogiri'
 require 'tmpdir'
 require_relative 'test__helper'
 require_relative '../objects/log'
-require_relative '../objects/dynamo'
+
+class FakeDynamoLog
+  def initialize
+    @items = {}
+  end
+
+  def put_item(table_name:, item:)
+    @items[item['repo']] ||= []
+    @items[item['repo']] << item.merge('table' => table_name)
+  end
+
+  def query(table_name:, expression_attribute_values:, **_options)
+    repo = expression_attribute_values.fetch(':r')
+    tag = expression_attribute_values.fetch(':t')
+    items = @items.fetch(repo, []).select do |item|
+      item['table'] == table_name && item['tag'] == tag
+    end
+    OpenStruct.new(items: items)
+  end
+end
 
 # Log test.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
@@ -13,9 +32,28 @@ require_relative '../objects/dynamo'
 # License:: MIT
 class TestLog < Minitest::Test
   def test_put_and_check
-    log = Log.new(Dynamo.new.aws, 'yegor256/0pdd')
+    log = Log.new(FakeDynamoLog.new, 'yegor256/0pdd')
     tag = 'some-tag'
     log.put(tag, 'some text here')
     assert(log.exists(tag))
+  end
+
+  def test_separates_same_repo_between_vcs
+    dynamo = FakeDynamoLog.new
+    repo = 'yegor256/0pdd'
+    tag = 'same-tag'
+    github = Log.new(dynamo, repo, 'github')
+    gitlab = Log.new(dynamo, repo, 'gitlab')
+    github.put(tag, 'github text')
+    refute(gitlab.exists(tag))
+    gitlab.put(tag, 'gitlab text')
+    assert(gitlab.exists(tag))
+    refute_equal(github.get(tag)['repo'], gitlab.get(tag)['repo'])
+  end
+
+  def test_rejects_unknown_vcs
+    assert_raises(RuntimeError) do
+      Log.new(FakeDynamoLog.new, 'yegor256/0pdd', 'unknown')
+    end
   end
 end


### PR DESCRIPTION
Fixes #354.

Summary:
- accept GitLab in `Log` and keep GitHub repo keys unchanged
- use a VCS-prefixed encoded key for non-GitHub log entries so the same `<user/repo>` on different VCS providers does not share duplicate-detection state
- report GitLab repositories as `gitlab` and add regression coverage for log key isolation and VCS naming

Validation:
- `ruby -c objects/log.rb && ruby -c objects/vcs/gitlab.rb && ruby -c test/test_log.rb && ruby -c test/test_gitlab_repo.rb` -> Syntax OK
- custom log VCS isolation test -> PASS
- custom GitLab VCS name test -> PASS
- `git diff --check` -> no output
- `git diff | gitleaks stdin --redact --no-banner` -> no leaks found

Not run locally:
- `bundle exec rake` / `bundle exec rubocop`: this macOS 12 host lacked Ruby 3.3, Maven, and Java initially; Homebrew fell back to building LLVM from source for Ruby 3.3 and the setup attempt was stopped after about 20 minutes.