### PR TITLE
#351 isolate GitHub close failures

### DIFF
--- a/objects/puzzles.rb
+++ b/objects/puzzles.rb
@@ -78,6 +78,7 @@ class Puzzles
       )
       break if puzzles.empty?
       puzzle = puzzles[0]
+      seen << puzzle.xpath('id')[0].text
       puzzle.search('issue')[0]['closed'] = Time.now.iso8601 if tickets.close(puzzle)
       save(xml)
     end

--- a/objects/tickets/tickets.rb
+++ b/objects/tickets/tickets.rb
@@ -37,8 +37,8 @@ class Tickets
   def close(puzzle)
     issue = puzzle.xpath('issue')[0].text
     return true if @vcs.issue(issue)[:state] == 'closed'
-    @vcs.close_issue(issue)
-    @vcs.add_comment(
+    return false unless @vcs.close_issue(issue)
+    return false unless @vcs.add_comment(
       issue,
       [
         "The puzzle `#{puzzle.xpath('id')[0].text}` has disappeared",

--- a/objects/vcs/github.rb
+++ b/objects/vcs/github.rb
@@ -46,11 +46,12 @@ class GithubRepo
     }
   end
 
-  # @todo #312:30min Currently, if 0pdd fails to close an issue it causes all other downstream execution to be skipped
-  #  therefore leaving the job in a non deterministic state. Catch and track the error here to
-  #  prevent this from happening. Also applies to `add_comment(...)`
   def close_issue(issue_id)
     @client.close_issue(@repo.name, issue_id)
+    true
+  rescue Octokit::Error => e
+    puts "Can't close issue ##{issue_id} in #{@repo.name}: #{e.message}"
+    false
   end
 
   def create_issue(data)
@@ -82,6 +83,10 @@ class GithubRepo
 
   def add_comment(issue_id, comment)
     @client.add_comment(@repo.name, issue_id, comment)
+    true
+  rescue Octokit::Error => e
+    puts "Can't comment on issue ##{issue_id} in #{@repo.name}: #{e.message}"
+    false
   end
 
   def create_commit_comment(sha, comment)

--- a/test/fake_github.rb
+++ b/test/fake_github.rb
@@ -89,7 +89,9 @@ class FakeGithub
     }
   end
 
-  def close_issue(_); end
+  def close_issue(_)
+    true
+  end
 
   def create_issue(_)
     {
@@ -114,7 +116,9 @@ class FakeGithub
 
   def add_labels_to_an_issue(_, _); end
 
-  def add_comment(_, _); end
+  def add_comment(_, _)
+    true
+  end
 
   def create_commit_comment(_, _, _)
     {

--- a/test/fake_gitlab.rb
+++ b/test/fake_gitlab.rb
@@ -29,7 +29,9 @@ class FakeGitlab
     }
   end
 
-  def close_issue(_); end
+  def close_issue(_)
+    true
+  end
 
   def create_issue(_)
     {
@@ -54,7 +56,9 @@ class FakeGitlab
 
   def add_labels_to_an_issue(_, _); end
 
-  def add_comment(_, _); end
+  def add_comment(_, _)
+    true
+  end
 
   def create_commit_comment(_, _)
     {

--- a/test/test_github_repo.rb
+++ b/test/test_github_repo.rb
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'test__helper'
+require_relative '../objects/vcs/github'
+
+# GithubRepo test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2016-2026 Yegor Bugayenko
+# License:: MIT
+class TestGithubRepo < Minitest::Test
+  def test_tracks_close_failures
+    client = Object.new
+    response = error_response
+    client.define_singleton_method(:close_issue) do |_, _|
+      raise Octokit::Error, response
+    end
+    refute(repo(client).close_issue(1))
+  end
+
+  def test_tracks_comment_failures
+    client = Object.new
+    response = error_response
+    client.define_singleton_method(:add_comment) do |_, _, _|
+      raise Octokit::Error, response
+    end
+    refute(repo(client).add_comment(1, 'hello'))
+  end
+
+  private
+
+  def repo(client)
+    GithubRepo.new(
+      client,
+      {
+        'repository' => {
+          'ssh_url' => 'git@github.com:yegor256/0pdd.git',
+          'url' => 'https://github.com/yegor256/0pdd',
+          'full_name' => 'yegor256/0pdd',
+          'master_branch' => 'master'
+        },
+        'ref' => 'refs/heads/master',
+        'head_commit' => {
+          'id' => 'abc'
+        }
+      },
+      {}
+    )
+  end
+
+  def error_response
+    {
+      method: :patch,
+      url: 'https://api.github.test/repos/yegor256/0pdd/issues/1',
+      status: 500,
+      body: 'boom',
+      response_headers: {}
+    }
+  end
+end

--- a/test/test_github_tickets.rb
+++ b/test/test_github_tickets.rb
@@ -188,4 +188,29 @@ format:
       ).xpath('/puzzle')
     )
   end
+
+  def test_does_not_comment_when_close_fails
+    repo = object(
+      name: 'github',
+      config: {},
+      head_commit_hash: '123',
+      master: 'master'
+    )
+    require_relative 'fake_github'
+    vcs = FakeGithub.new(repo: repo)
+    def vcs.close_issue(_)
+      false
+    end
+
+    def vcs.add_comment(_, _)
+      raise 'should not comment'
+    end
+    refute(
+      Tickets.new(vcs).close(
+        Nokogiri::XML(
+          '<puzzle><id>xx</id><issue>1</issue></puzzle>'
+        ).xpath('/puzzle')
+      )
+    )
+  end
 end

--- a/test/test_puzzles.rb
+++ b/test/test_puzzles.rb
@@ -49,6 +49,40 @@ class TestPuzzles < Minitest::Test
     end
   end
 
+  def test_keeps_closing_after_failed_close
+    closed = []
+    tickets = Object.new
+    tickets.define_singleton_method(:close) do |puzzle|
+      id = puzzle.xpath('id')[0].text
+      if id == 'first'
+        false
+      else
+        closed << id
+        true
+      end
+    end
+    Dir.mktmpdir 'test' do |dir|
+      storage = FakeStorage.new(
+        dir,
+        Nokogiri.XML(
+          '<puzzles>
+            <puzzle alive="false"><id>first</id><issue>1</issue></puzzle>
+            <puzzle alive="false"><id>second</id><issue>2</issue></puzzle>
+          </puzzles>'
+        )
+      )
+      Puzzles.new(OpenStruct.new(config: {}), storage).send(
+        :expose,
+        storage.load,
+        tickets
+      )
+      after = storage.load
+      assert_equal(['second'], closed)
+      assert_empty(after.xpath("//puzzle[id='first']/issue/@closed"))
+      refute_empty(after.xpath("//puzzle[id='second']/issue/@closed"))
+    end
+  end
+
   private
 
   def test_xml(dir, name, ordered: false)


### PR DESCRIPTION
Summary:
- rescue Octokit close/comment failures in GithubRepo and return false instead of raising
- make Tickets#close respect failed close/comment responses
- advance the lost-puzzle close loop after a failed close so later puzzles still run

Validation:
- PICKS=1 mise exec ruby@3.3.11 -- bundle exec ruby -Itest -e "require './test/test_puzzles'; require './test/test_github_repo'; require './test/test_github_tickets'" -> 11 tests, 69 assertions, 0 failures, 0 errors
- mise exec ruby@3.3.11 -- bundle exec rubocop objects/vcs/github.rb objects/tickets/tickets.rb objects/puzzles.rb test/fake_github.rb test/fake_gitlab.rb test/test_puzzles.rb test/test_github_repo.rb test/test_github_tickets.rb -> 8 files inspected, no offenses
- mise exec ruby@3.3.11 -- bundle exec xcop --quiet . -> passed
- git diff --cached --check -> passed
- git diff --cached | gitleaks stdin --redact --no-banner -> no leaks found

Limitation:
- mise exec ruby@3.3.11 -- bundle exec rake test is blocked locally because Maven/Java are not installed; it aborts before tests at Rakefile:39 with Errno::ENOENT: No such file or directory - mvn.