### PR TITLE
#591: Use rewindable request body

### DIFF
--- a/0pdd.rb
+++ b/0pdd.rb
@@ -133,8 +133,6 @@ configure do
   end
 end
 use Rack::Deflater
-# @todo #572:1h rewind is removed from rack 3.0, so it is moved to
-#  rewindableInput for now, but it is better to check another solutions
 use Rack::RewindableInput::Middleware
 
 before '/*' do
@@ -339,8 +337,7 @@ post '/hook/github' do
       'Please, only register push events from GitHub webhook'
     ]
   end
-  request.env['rack.input'].rewind if request.env['rack.input'].respond_to?(:rewind)
-  request.body.rewind unless request.env['rack.input'].respond_to?(:rewind)
+  request.body.rewind
   json = JSON.parse(
     case request.content_type
     when 'application/x-www-form-urlencoded'
@@ -384,8 +381,7 @@ post '/hook/gitlab' do
       'Please, only register push events from Gitlab webhook'
     ]
   end
-  request.env['rack.input'].rewind if request.env['rack.input'].respond_to?(:rewind)
-  request.body.rewind unless request.env['rack.input'].respond_to?(:rewind)
+  request.body.rewind
   json = JSON.parse(
     case request.content_type
     when 'application/x-www-form-urlencoded'

--- a/test/test_0pdd.rb
+++ b/test/test_0pdd.rb
@@ -92,6 +92,27 @@ class AppTest < Minitest::Test
     assert_includes(last_response.body, 'Thanks')
   end
 
+  def test_it_understands_form_push_from_github
+    headers = {
+      'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+      'HTTP_USER_AGENT' => 'GitHub-Hookshot',
+      'HTTP_X_GITHUB_EVENT' => 'push'
+    }
+    payload = [
+      '{"head_commit":{"id":"-"},',
+      '"repository":{"url":"localhost",',
+      '"full_name":"yegor256-one/com.github.0pdd-test"},',
+      '"ref":"refs/heads/master"}'
+    ].join
+    post(
+      '/hook/github',
+      Rack::Utils.build_query(payload: payload),
+      headers
+    )
+    assert_predicate(last_response, :ok?)
+    assert_includes(last_response.body, 'Thanks')
+  end
+
   def test_it_ignores_push_from_github_to_not_master
     headers = {
       'CONTENT_TYPE' => 'application/json',
@@ -163,6 +184,27 @@ class AppTest < Minitest::Test
        '"project":{"url":"localhost",',
        '"path_with_namespace":"yegor256-one/com.github.0pdd-test"},',
        '"ref":"refs/heads/master"}'].join,
+      headers
+    )
+    assert_predicate(last_response, :ok?)
+    assert_includes(last_response.body, 'Thanks')
+  end
+
+  def test_it_understands_form_push_from_gitlab
+    headers = {
+      'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+      'HTTP_USER_AGENT' => 'GitLab 16.6',
+      'HTTP_X_GITLAB_EVENT' => 'Push Hook'
+    }
+    payload = [
+      '{"checkout_sha": "da1560886d4",',
+      '"project":{"url":"localhost",',
+      '"path_with_namespace":"yegor256-one/com.github.0pdd-test"},',
+      '"ref":"refs/heads/master"}'
+    ].join
+    post(
+      '/hook/gitlab',
+      Rack::Utils.build_query(payload: payload),
       headers
     )
     assert_predicate(last_response, :ok?)


### PR DESCRIPTION
Closes #591.

Summary:
- keep `Rack::RewindableInput::Middleware` as the Rack 3 body wrapper
- use `request.body.rewind` directly in GitHub and GitLab hooks
- cover URL-encoded webhook payloads for both providers

Validation:
- `PICKS=1 mise exec ruby@3.3.11 -- bundle exec ruby -Itest test/test_0pdd.rb --name "/test_it_understands_(form_)?push_from_(github|gitlab)/"` -> 4 tests, 16 assertions, 0 failures
- `PICKS=1 mise x java@temurin-21.0.11+10.0.LTS maven@3.9.16 ruby@3.3.11 -- bundle exec rake test TEST=test/test_0pdd.rb TESTOPTS="--name=test_it_understands_form_push_from_github"` -> 1 test, 4 assertions, 0 failures
- `mise exec ruby@3.3.11 -- bundle exec rubocop 0pdd.rb test/test_0pdd.rb` -> 2 files inspected, no offenses
- `mise exec ruby@3.3.11 -- bundle exec xcop --quiet .` -> passed
- `ruby -c 0pdd.rb && ruby -c test/test_0pdd.rb` -> Syntax OK
- `git diff --check HEAD~1..HEAD` -> passed
- `git show --format= --no-ext-diff HEAD | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found

Limit: I did not run the full all-test `rake test` suite locally; the validation above is scoped to the changed hook behavior plus style/XML/diff/secret checks.
