### PR TITLE
#562: Test linear ranking

### DIFF
--- a/model/linear.rb
+++ b/model/linear.rb
@@ -10,10 +10,6 @@ require_relative 'fake_weights_storage'
 
 #
 # Linear Model
-# @todo #532:60min Add unit-tests.
-#  We should add unit-tests for this class that checks puzzle ranking.
-#  For now its untested, don't forget to remove this puzzle.
-#
 class LinearModel
   def initialize(repo, storage)
     @repo = repo

--- a/test/test_linear_model.rb
+++ b/test/test_linear_model.rb
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'test__helper'
+require_relative 'fake_storage'
+require_relative '../model/linear'
+
+# LinearModel test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2016-2026 Yegor Bugayenko
+# License:: MIT
+class TestLinearModel < Minitest::Test
+  def test_ranks_puzzles_by_estimate
+    assert_equal(
+      [1, 2, 0],
+      LinearModel.new(
+        'yegor256/0pdd',
+        FakeStorage.new
+      ).predict(
+        [
+          { 'id' => 'slow', 'estimate' => '30', 'body' => 'slow puzzle' },
+          { 'id' => 'fast', 'estimate' => '5', 'body' => 'fast puzzle' },
+          { 'id' => 'medium', 'estimate' => '10', 'body' => 'medium puzzle' }
+        ]
+      )
+    )
+  end
+end


### PR DESCRIPTION
Closes #562.

Summary:
- add a focused `LinearModel` unit test for fallback puzzle ranking
- verify `predict` returns input indexes ordered by puzzle estimate
- remove the solved PDD from `model/linear.rb`

Validation:
- `PICKS=1 mise exec ruby@3.3.11 -- bundle exec ruby -Itest test/test_linear_model.rb` -> `1` test, `1` assertion, `0` failures, `0` errors.
- `PICKS=1 mise x java@temurin-21.0.11+10.0.LTS maven@3.9.16 ruby@3.3.11 -- bundle exec rake test TEST=test/test_linear_model.rb` -> `1` test, `1` assertion, `0` failures, `0` errors.
- `mise exec ruby@3.3.11 -- bundle exec rubocop model/linear.rb test/test_linear_model.rb` -> `2` files inspected, no offenses.
- `mise exec ruby@3.3.11 -- bundle exec xcop --quiet .` -> passed.
- `mise exec ruby@3.3.11 -- ruby -c model/linear.rb && mise exec ruby@3.3.11 -- ruby -c test/test_linear_model.rb` -> Syntax OK.
- `git diff --check HEAD~1..HEAD` -> passed.
- `git show --format= --no-ext-diff HEAD | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found.

Limitation:
- I did not run the full all-test suite; validation is scoped to the new `LinearModel` test plus style, XML, syntax, diff, and secret checks.
